### PR TITLE
fix: don't refresh access token for get methods

### DIFF
--- a/across/sdk/v1/api_client_wrapper.py
+++ b/across/sdk/v1/api_client_wrapper.py
@@ -97,7 +97,8 @@ class ApiClientWrapper(sdk.ApiClient):
         return cls._client
 
     def call_api(self, *args, **kwargs) -> rest.RESTResponse:
-        self.refresh()
+        if args[0].lower() != "get":
+            self.refresh()
 
         try:
             return super().call_api(*args, **kwargs)
@@ -158,6 +159,9 @@ class ApiClientWrapper(sdk.ApiClient):
     def _is_token_invalid(self, jwt_token):
         """Returns True when the token is expired, malformed, or missing expiration"""
         # JWT contains 3 parts, we're looking for the middle part; the payload with the exp key
+        if not isinstance(jwt_token, str):
+            return True
+        
         jwt_parts = jwt_token.split('.')
 
         if len(jwt_parts) != 3:


### PR DESCRIPTION
### Description

This PR fixes a bug when using the sdk to make `GET` requests without credentials or an access token. This would lead to a crash when trying to refresh the non-existent JWT. It will now skip refreshing the access token for `GET` requests, which allows these endpoints to be accessed without authentication. This PR also adds a check that the JWT is a string before attempting to decode it to avoid a crash if the access token is `None`.

### Related Issue(s)

Resolves #9 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. Should be able to use the SDK to make `GET` requests without credentials

### Testing

1. Install this branch as a dependency of `across-client`
2. In `across-client`, initialize a `Client` object without credentials and try to access an SSA model endpoint, e.g. `client.observatory.get_many()`
3. You should get back a response without an error