### PR TITLE
fix(namespace): add code to fix namespace issue due to boilerplate

### DIFF
--- a/across/__init__.py
+++ b/across/__init__.py
@@ -17,3 +17,5 @@ of the National Aeronautics and Space Administration and The Penn State
 Research Foundation.  All rights reserved. This software is licensed under the
 Apache 2.0 License.
 """
+
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
## Title

fix(namespace): add code to fix namespace issue due to boilerplate

### Description

This PR fixes the namespace issue that was causing Github actions to fail. 

### Related Issue(s)

Resolves #17 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

Github actions work again.

### Testing

1. Installed a basic Ubuntu Docker image and logged into it.  `docker pull ubuntu` , `docker run -it ubuntu /bin/bash\n`
2. `apt-get update` followed by `apt-get install git nano curl`
3. Install `uv` as such: `curl -LsSf https://astral.sh/uv/install.sh | sh`
4. Source the `uv` setup that comes out on stdout.
5. Git clone `across-client` and `across-server-openapi-python`.
6. Go into `across-client` and `uv venv` to create a virtual environment, activate it.
7. `git checkout 34-remove-ssh-from-gha`
8. `uv pip install .`
9. From python do `import across.client` and witness errors.
11. With `nano` add the line above to `__init__.py` in both repos.
12. Do `uv pip install ../across-server-openapi-python` from `across-client`
13. From python do the `import across.client` again, and witness it working.
